### PR TITLE
Template Sections externally + Engine syntax fix

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -320,7 +320,7 @@ class Engine
             } unset($layout);
         }
         
-        if(!empty($layouts)) $tpl->layoutsAdd(0, $layouts);
+        if(!empty($layouts)) $tpl->layouts($layouts);
         
         return $tpl->render($tplData);
     }

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -68,7 +68,7 @@ class Engine
     }
 
     public static function fromTheme(Theme $theme, string $fileExtension = 'php'): self {
-        $engine = new self(null, $fileExtension);
+        $engine = new static(null, $fileExtension);
         $engine->setResolveTemplatePath(new ResolveTemplatePath\ThemeResolveTemplatePath($theme));
         return $engine;
     }

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -203,10 +203,10 @@ class Template
     }
 
     /**
-     * Set the template's layout.
+     * Set the template's layout, and return self.
      * @param  string $name
      * @param  array  $data
-     * @return Template|array
+     * @return Template
      */
     public function layout($name = null, array $data = array())
     {
@@ -273,6 +273,9 @@ class Template
       return $this;
     }
     
+    public function getSections() {return $this->sections;}
+    public function setSections($sections) {$this->sections = $sections; return $this;}
+
     /**
      * Start a new section block.
      * @param  string  $name


### PR DESCRIPTION
Allow Template Sections to be used externally (eg to call a layout providing "content" without the need to make a Template for the sole purpose of calling the Layout...)